### PR TITLE
Update update-deb-archive

### DIFF
--- a/update-deb-archive
+++ b/update-deb-archive
@@ -34,7 +34,7 @@ function update_distribution() {
     gpg --default-key=EMC --detach-sign --armor -o ${RELEASE_GPG} ${RELEASE}
 
     rm -f $INRELEASE
-    gpg --default-key=EMC --clear-sign --armor -o ${INRELEASE} ${RELEASE}
+    gpg --default-key=EMC --clear-sign --digest-algo SHA256 --armor -o ${INRELEASE} ${RELEASE}
 }
 
 if [ -z "$*" ]; then


### PR DESCRIPTION
I found that the InRelease signing was considered invalid because the file was signed using SHA1 by default. 
This is probably over-ridden by a local config in many cases, but this makes it explicit in the script.